### PR TITLE
Try same qemu.conf as we use for Caracal in tigera/calico-test

### DIFF
--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -75,14 +75,16 @@ EOF
 		    # Update qemu configuration (shouldn't be anything
 		    # in there so safe to blow away)
 		    sudo sh -c "cat > /etc/libvirt/qemu.conf" << EOF
-user = "root"
-group = "root"
 cgroup_device_acl = [
     "/dev/null", "/dev/full", "/dev/zero",
     "/dev/random", "/dev/urandom",
     "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
     "/dev/rtc", "/dev/hpet", "/dev/net/tun",
+    "/dev/vfio/vfio",
 ]
+dynamic_ownership = 0
+user = "nova"
+group = "nova"
 EOF
 
 		    # Use the Calico plugin.  We make this change here, instead


### PR DESCRIPTION
This is a guess, based on the error being a "Permission denied" one, which is similar to what I saw when debugging failures in the Caracal update.

This is the error, from the journalctl.txt artifact:

    Apr 30 20:53:34 semaphore-vm nova-compute[72329]: : libvirt.libvirtError: Cannot access storage file '/opt/stack/data/nova/instances/d231bdf6-40a9-4959-845d-fc6bb10c3628/disk' (as uid:64055, gid:108): Permission denied

This is the configuration in tigera/calico-test: https://github.com/tigera/calico-test/blob/bobcat/calicotest/openstack/install/gce/scripts/gce_compute_ubuntu.sh#L195-L222